### PR TITLE
Remove dynamic linking stanza in Snappy's conanfile.py

### DIFF
--- a/recipes/snappy/all/conanfile.py
+++ b/recipes/snappy/all/conanfile.py
@@ -96,8 +96,5 @@ class SnappyConan(ConanFile):
         if not self.options.shared:
             if self.settings.os in ["Linux", "FreeBSD"]:
                 self.cpp_info.components["snappylib"].system_libs.append("m")
-            libcxx = stdcpp_library(self)
-            if libcxx:
-                self.cpp_info.components["snappylib"].system_libs.append(libcxx)
 
         self.cpp_info.components["snappylib"].set_property("cmake_target_name", "Snappy::snappy")


### PR DESCRIPTION
These lines cause our binaries to be dynamically linked. See https://github.com/conan-io/conan/issues/15646 for more context.