### PR TITLE
Add patch for Soci 4.0.3

### DIFF
--- a/recipes/soci/all/conandata.yml
+++ b/recipes/soci/all/conandata.yml
@@ -10,3 +10,6 @@ patches:
     - patch_file: "patches/0001-Remove-hardcoded-INSTALL_NAME_DIR-for-relocatable-li.patch"
       patch_description: "Generate relocatable libraries on MacOS"
       patch_type: "portability"
+    - patch_file: "patches/0002-Fix-soci_backend.patch"
+      patch_description: "Fix variable names for dependencies"
+      patch_type: "conan"

--- a/recipes/soci/all/patches/0002-Fix-soci_backend.patch
+++ b/recipes/soci/all/patches/0002-Fix-soci_backend.patch
@@ -1,0 +1,24 @@
+diff --git a/cmake/SociBackend.cmake b/cmake/SociBackend.cmake
+index 0a664667..3fa2ed95 100644
+--- a/cmake/SociBackend.cmake
++++ b/cmake/SociBackend.cmake
+@@ -31,14 +31,13 @@ macro(soci_backend_deps_found NAME DEPS SUCCESS)
+     if(NOT DEPEND_FOUND)
+       list(APPEND DEPS_NOT_FOUND ${dep})
+     else()
+-      string(TOUPPER "${dep}" DEPU)
+-      if( ${DEPU}_INCLUDE_DIR )
+-        list(APPEND DEPS_INCLUDE_DIRS ${${DEPU}_INCLUDE_DIR})
++      if( ${dep}_INCLUDE_DIR )
++        list(APPEND DEPS_INCLUDE_DIRS ${${dep}_INCLUDE_DIR})
+       endif()
+-      if( ${DEPU}_INCLUDE_DIRS )
+-        list(APPEND DEPS_INCLUDE_DIRS ${${DEPU}_INCLUDE_DIRS})
++      if( ${dep}_INCLUDE_DIRS )
++        list(APPEND DEPS_INCLUDE_DIRS ${${dep}_INCLUDE_DIRS})
+       endif()
+-      list(APPEND DEPS_LIBRARIES ${${DEPU}_LIBRARIES})
++      list(APPEND DEPS_LIBRARIES ${${dep}_LIBRARIES})
+     endif()
+   endforeach()
+


### PR DESCRIPTION
This patch matches what was done in `XRPLF/rippled` to compile the binary.