### PR TITLE
Fix protobuf/6.30.1 compatibility issues with clang-16 and MSVC

### DIFF
--- a/recipes/protobuf/all/conandata.yml
+++ b/recipes/protobuf/all/conandata.yml
@@ -21,6 +21,15 @@ sources:
     url: "https://github.com/protocolbuffers/protobuf/archive/v3.20.3.tar.gz"
     sha256: "9c0fd39c7a08dff543c643f0f4baf081988129a411b977a07c46221793605638"
 patches:
+  "6.30.1":
+    - patch_file: "patches/protobuf-6.30.1-change-empty-string.patch"
+      patch_description: "Change how we decide which empty string implementation to use"
+      patch_type: "backport"
+      patch_source: "https://github.com/protocolbuffers/protobuf/issues/20645"
+    - patch_file: "patches/protobuf-6.30.1-disable-fixed-string-MSVC.patch"
+      patch_description: "Disable the optimization for fixed_address_empty_string for MSVC"
+      patch_type: "backport"
+      patch_source: "https://github.com/protocolbuffers/protobuf/issues/21957"
   "3.21.12":
     - patch_file: "patches/protobuf-3.21.12-upstream-macos-macros.patch"
       patch_description: "Handle case where macOS SDK macros may conflict with protobuf message types"

--- a/recipes/protobuf/all/patches/protobuf-6.30.1-change-empty-string.patch
+++ b/recipes/protobuf/all/patches/protobuf-6.30.1-change-empty-string.patch
@@ -1,0 +1,70 @@
+diff --git a/src/google/protobuf/port.cc b/src/google/protobuf/port.cc
+index af668e9e2..d60c2b89f 100644
+--- a/src/google/protobuf/port.cc
++++ b/src/google/protobuf/port.cc
+@@ -97,14 +97,9 @@ void RealDebugCounter::Register(absl::string_view name) {
+   }
+ }
+
+-#if defined(__cpp_lib_constexpr_string) && __cpp_lib_constexpr_string >= 201907L
+-PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT const GlobalEmptyString
+-    fixed_address_empty_string{};
+-#else
+ PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 GlobalEmptyString
+         fixed_address_empty_string{};
+-#endif
+
+ }  // namespace internal
+ }  // namespace protobuf
+diff --git a/src/google/protobuf/port.h b/src/google/protobuf/port.h
+index 5f9e909a0..386ecc02a 100644
+--- a/src/google/protobuf/port.h
++++ b/src/google/protobuf/port.h
+@@ -494,20 +494,27 @@ class NoopDebugCounter {
+ // Default empty string object. Don't use this directly. Instead, call
+ // GetEmptyString() to get the reference. This empty string is aligned with a
+ // minimum alignment of 8 bytes to match the requirement of ArenaStringPtr.
+-#if defined(__cpp_lib_constexpr_string) && __cpp_lib_constexpr_string >= 201907L
++
+ // Take advantage of C++20 constexpr support in std::string.
+-class alignas(8) GlobalEmptyString {
++class alignas(8) GlobalEmptyStringConstexpr {
+  public:
+   const std::string& get() const { return value_; }
+   // Nothing to init, or destroy.
+   std::string* Init() const { return nullptr; }
+
++  template <typename T = std::string, bool = (T(), true)>
++  static constexpr std::true_type HasConstexprDefaultConstructor(int) {
++    return {};
++  }
++  static constexpr std::false_type HasConstexprDefaultConstructor(char) {
++    return {};
++  }
++
+  private:
+   std::string value_;
+ };
+-PROTOBUF_EXPORT extern const GlobalEmptyString fixed_address_empty_string;
+-#else
+-class alignas(8) GlobalEmptyString {
++
++class alignas(8) GlobalEmptyStringDynamicInit {
+  public:
+   const std::string& get() const {
+     return *reinterpret_cast<const std::string*>(internal::Launder(buffer_));
+@@ -519,8 +526,12 @@ class alignas(8) GlobalEmptyString {
+  private:
+   alignas(std::string) char buffer_[sizeof(std::string)];
+ };
++
++using GlobalEmptyString = std::conditional_t<
++    GlobalEmptyStringConstexpr::HasConstexprDefaultConstructor(0),
++    const GlobalEmptyStringConstexpr, GlobalEmptyStringDynamicInit>;
++
+ PROTOBUF_EXPORT extern GlobalEmptyString fixed_address_empty_string;
+-#endif
+
+ }  // namespace internal
+ }  // namespace protobuf

--- a/recipes/protobuf/all/patches/protobuf-6.30.1-disable-fixed-string-MSVC.patch
+++ b/recipes/protobuf/all/patches/protobuf-6.30.1-disable-fixed-string-MSVC.patch
@@ -1,0 +1,21 @@
+diff --git a/src/google/protobuf/port.h b/src/google/protobuf/port.h
+index 386ecc02a..32d260c42 100644
+--- a/src/google/protobuf/port.h
++++ b/src/google/protobuf/port.h
+@@ -502,10 +502,16 @@ class alignas(8) GlobalEmptyStringConstexpr {
+   // Nothing to init, or destroy.
+   std::string* Init() const { return nullptr; }
+
++  // Disable the optimization for MSVC.
++  // There are some builds where the default constructed string can't be used as
++  // `constinit` even though the constructor is `constexpr` and can be used
++  // during constant evaluation.
++#if !defined(_MSC_VER)
+   template <typename T = std::string, bool = (T(), true)>
+   static constexpr std::true_type HasConstexprDefaultConstructor(int) {
+     return {};
+   }
++#endif
+   static constexpr std::false_type HasConstexprDefaultConstructor(char) {
+     return {};
+   }


### PR DESCRIPTION
**Summary**
Changes to recipe: **protobuf/6.30.1**

**Motivation**
This fixes two compatibility issues in protobuf version 6.30.1 :

* https://github.com/protocolbuffers/protobuf/issues/20645 fixed in https://github.com/protocolbuffers/protobuf/commit/3dfd88f3da03e1eef86889eb0eb94887689ed51d
* https://github.com/protocolbuffers/protobuf/issues/21957 fixed in https://github.com/protocolbuffers/protobuf/commit/185ee1dd1105073ad8cc52b8fc179ce00f621cc9

Both patches are classed as `backport`, since they apply fixes from a more recent protobuf release, on top of version 6.30.1

**Details**
Projects using protobuf/6.30.1 will fail to build with clang-16 e.g. on Debian 12 ; or when built with MSVC. This fixes the problem.