### PR TITLE
GitHub ternary operator doesn't handle the empty string

### DIFF
--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -40,8 +40,11 @@ jobs:
           conan export protobuf/all --version=6.30.1
           conan export snappy/all --version=1.1.10
           conan export soci/all --version=4.0.3
-      - name: Upload the recipes
+      - name: Upload the recipes (dry run)
+        if: ${{ github.ref_type == 'branch' && github.ref_name != github.event.repository.default_branch }}
         run: |
-          conan upload '*' --confirm --check --only-recipe \
-          --remote ${{ env.CONAN_REMOTE_NAME }} \
-          ${{ github.ref_type == 'branch' && github.ref_name == github.event.repository.default_branch && '' || '--dry-run'}}
+          conan upload '*' --confirm --check --only-recipe --remote ${{ env.CONAN_REMOTE_NAME }} --dry-run
+      - name: Upload the recipes
+        if: ${{ github.ref_type == 'branch' && github.ref_name == github.event.repository.default_branch }}
+        run: |
+          conan upload '*' --confirm --check --only-recipe --remote ${{ env.CONAN_REMOTE_NAME }}

--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -41,10 +41,7 @@ jobs:
           conan export snappy/all --version=1.1.10
           conan export soci/all --version=4.0.3
       - name: Upload the recipes (dry run)
-        if: ${{ github.ref_type == 'branch' && github.ref_name != github.event.repository.default_branch }}
-        run: |
-          conan upload '*' --confirm --check --only-recipe --remote ${{ env.CONAN_REMOTE_NAME }} --dry-run
+        run: conan upload '*' --confirm --check --only-recipe --remote ${{ env.CONAN_REMOTE_NAME }} --dry-run
       - name: Upload the recipes
         if: ${{ github.ref_type == 'branch' && github.ref_name == github.event.repository.default_branch }}
-        run: |
-          conan upload '*' --confirm --check --only-recipe --remote ${{ env.CONAN_REMOTE_NAME }}
+        run: conan upload '*' --confirm --check --only-recipe --remote ${{ env.CONAN_REMOTE_NAME }}


### PR DESCRIPTION
The current case hit https://github.com/actions/runner/issues/409#issuecomment-1013325196, so the dry-run was always triggered.