### PR TITLE
Revert "Restore GCC15 fix for M4"

### DIFF
--- a/recipes/m4/all/conanfile.py
+++ b/recipes/m4/all/conanfile.py
@@ -64,12 +64,6 @@ class M4Conan(ConanFile):
             # WORKAROUND: https://lists.buildroot.org/pipermail/buildroot/2025-May/777741.html
             tc.extra_cflags.append("-std=gnu17")
 
-        if self.settings.compiler == "gcc" and Version(self.settings.compiler.version) >= 15:
-            # The gnulib copy included in m4 1.4.19 does not detect properly the default C
-            # language standard of gcc 15, which has been changed from "gnu17" to "gnu23",
-            # see https://lists.buildroot.org/pipermail/buildroot/2025-May/777741.html.
-            tc.extra_cflags.append("-std=gnu17")
-
         if cross_building(self) and is_msvc(self):
             triplet_arch_windows = {"x86_64": "x86_64", "x86": "i686", "armv8": "aarch64"}
             


### PR DESCRIPTION
This reverts commit 58bde7e3554ed62f926b5b5b7ff0b88685ef429a.

We no longer need it, since upstream has updated the recipe in a very similar fashion, and I've updated our fork.
https://github.com/conan-io/conan-center-index/pull/30079

I will remove m4 from export after we merge this