### PR TITLE
secp256k1: export field and group internal headers to private/

### DIFF
--- a/recipes/secp256k1/all/conanfile.py
+++ b/recipes/secp256k1/all/conanfile.py
@@ -46,8 +46,10 @@ class SecpConan(ConanFile):
         cmake.install()
 
         # These headers are used by XRPLF/mpt-crypto which is why we need to package them.
-        src_headers = ["util.h", "int128.h", "int128_impl.h", "scalar.h", "scalar_impl.h"]
-        src_headers_dependencies = ["checkmem.h", "int128_native.h", "int128_native_impl.h", "scalar_4x64.h", "scalar_4x64_impl.h", "modinv64.h", "modinv64_impl.h", "int128_struct.h", "int128_struct_impl.h"]
+        src_headers = ["util.h", "int128.h", "int128_impl.h", "scalar.h", "scalar_impl.h",
+                       "field.h", "field_impl.h", "group.h", "group_impl.h"]
+        src_headers_dependencies = ["checkmem.h", "int128_native.h", "int128_native_impl.h", "scalar_4x64.h", "scalar_4x64_impl.h", "modinv64.h", "modinv64_impl.h", "int128_struct.h", "int128_struct_impl.h",
+                                    "field_5x52.h", "field_5x52_impl.h", "field_5x52_int128_impl.h", "field_10x26.h", "field_10x26_impl.h"]
         for header in src_headers + src_headers_dependencies:
             copy(
                 self,


### PR DESCRIPTION
Export `field.h`, `field_impl.h`, group.h, `group_impl.h` and their platform-specific dependencies to the `private` folder, following the same pattern used for scalar headers. Required by XRPLF/mpt-crypto for the BSGS DLP fast decryption implementation.