### PR TITLE
Support both remotes for now

### DIFF
--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -25,11 +25,20 @@ defaults:
 
 env:
   CONAN_REMOTE_NAME: xrplf
-  CONAN_REMOTE_URL: https://conan.xrplf.org/repository/conan/
 
 jobs:
   export:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - CONAN_REMOTE_URL: https://conan.xrplf.org/repository/conan/
+            CONAN_LOGIN_USERNAME_XRPLF: ${{ secrets.NEXUS_REMOTE_USERNAME }}
+            CONAN_PASSWORD_XRPLF: ${{ secrets.NEXUS_REMOTE_PASSWORD }}
+          - CONAN_REMOTE_URL: https://conan.ripplex.io
+            CONAN_LOGIN_USERNAME_XRPLF: ${{ secrets.CONAN_REMOTE_USERNAME }}
+            CONAN_PASSWORD_XRPLF: ${{ secrets.CONAN_REMOTE_PASSWORD }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -41,22 +50,27 @@ jobs:
           ./export_all.sh
 
       - name: Add Conan remote
+        env:
+          CONAN_REMOTE_URL: ${{ matrix.CONAN_REMOTE_URL }}
         run: |
-          conan remote add --index 0 ${CONAN_REMOTE_NAME} ${CONAN_REMOTE_URL}
+          conan remote add --index 0 "${CONAN_REMOTE_NAME}" "${CONAN_REMOTE_URL}"
 
       - name: Upload the recipes (dry run)
         run: |
-          conan upload '*' --confirm --check --only-recipe --remote ${CONAN_REMOTE_NAME} --dry-run
+          conan upload '*' --confirm --check --only-recipe --remote "${CONAN_REMOTE_NAME}" --dry-run
 
       - name: Log into Conan remote
         if: ${{ github.repository_owner == 'XRPLF' && github.event_name != 'pull_request' }}
+        env:
+          CONAN_LOGIN_USERNAME_XRPLF: ${{ matrix.CONAN_LOGIN_USERNAME_XRPLF }}
+          CONAN_PASSWORD_XRPLF: ${{ matrix.CONAN_PASSWORD_XRPLF }}
         run: |
-          conan remote login ${CONAN_REMOTE_NAME} ${{ secrets.NEXUS_REMOTE_USERNAME }} --password "${{ secrets.NEXUS_REMOTE_PASSWORD }}"
+          conan remote login "${CONAN_REMOTE_NAME}" "${CONAN_LOGIN_USERNAME_XRPLF}" --password "${CONAN_PASSWORD_XRPLF}"
           conan remote list-users
       - name: Upload the recipes
         if: ${{ github.repository_owner == 'XRPLF' && github.event_name != 'pull_request' }}
         env:
-          CONAN_LOGIN_USERNAME_XRPLF: ${{ secrets.NEXUS_REMOTE_USERNAME }}
-          CONAN_PASSWORD_XRPLF: ${{ secrets.NEXUS_REMOTE_PASSWORD }}
+          CONAN_LOGIN_USERNAME_XRPLF: ${{ matrix.CONAN_LOGIN_USERNAME_XRPLF }}
+          CONAN_PASSWORD_XRPLF: ${{ matrix.CONAN_PASSWORD_XRPLF }}
         run: |
-          conan upload '*' --confirm --check --only-recipe --remote ${CONAN_REMOTE_NAME}
+          conan upload '*' --confirm --check --only-recipe --remote "${CONAN_REMOTE_NAME}"


### PR DESCRIPTION
`mpt-crypto` wants to release a new version, but we might need to give some time to sunset the old remote, while supporting existing code.