### PR TITLE
Allow for building wasmi with code coverage turned on

### DIFF
--- a/recipes/wasmi/README.md
+++ b/recipes/wasmi/README.md
@@ -1,0 +1,24 @@
+## BUILD
+
+Install Rust
+```
+% curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh && source "$HOME/.cargo/env"
+```
+
+Build the wasmi recipe.  There is currently the following options(s);
+- coverage=[True, False] Defaults to false, only supported on LLVM
+```
+% conan create recipes/wasmi/all --version 1.0.9 -s build_type=Debug
+# Or with coverage
+% conan create recipes/wasmi/all --version 1.0.9 -o "wasmi/*:coverage=True" -s build_type=Debug
+```
+
+## Run the test
+```
+# From the root of this repo
+% ./recipes/wasmi/all/test_package/build/<compiler>/test_package 
+# or if coverage turned on
+% LLVM_PROFILE_FILE=wasmi.profraw ./recipes/wasmi/all/test_package/build/<compiler>/test_package  
+% llvm-profdata merge -sparse wasmi.profraw -o wasmi.profdata  
+% llvm-cov report ./recipes/wasmi/all/test_package/build/<compiler>/test_package  -instr-profile=wasmi.profdata
+```

--- a/recipes/wasmi/all/conanfile.py
+++ b/recipes/wasmi/all/conanfile.py
@@ -1,5 +1,6 @@
 from conan import ConanFile, tools
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.env import Environment
 from conan.tools.files import get
 import os
 
@@ -12,8 +13,8 @@ class WasmiConan(ConanFile):
     description = "WebAssembly (Wasm) interpreter"
     package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
-    options = {"shared": [False]}
-    default_options = {"shared": False}
+    options = {"shared": [False], "coverage": [True, False]}
+    default_options = {"shared": False, "coverage": False}
 
     def layout(self):
         cmake_layout(self, src_folder="src")
@@ -24,6 +25,11 @@ class WasmiConan(ConanFile):
     def generate(self):
         tc = CMakeToolchain(self)
         tc.generate()
+
+        if self.options.coverage:
+            env = Environment()
+            env.append("RUSTFLAGS", "-Cinstrument-coverage", separator=" ")
+            env.vars(self, scope="build").save_script("wasmi_coverage")
 
     def build(self):
         cmake = CMake(self)
@@ -36,3 +42,18 @@ class WasmiConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.libs = ["wasmi"]
+
+        if self.options.coverage:
+            compiler = str(self.settings.compiler)
+            if compiler in ("clang", "apple-clang"):
+                coverage_flags = ["-fprofile-instr-generate", "-fcoverage-mapping"]
+                self.cpp_info.cflags.extend(coverage_flags)
+                self.cpp_info.cxxflags.extend(coverage_flags)
+                self.cpp_info.exelinkflags.extend(coverage_flags)
+                self.cpp_info.sharedlinkflags.extend(coverage_flags)
+            else:
+                self.output.warning(
+                    "wasmi coverage=True has no effect with compiler '%s': libwasmi "
+                    "is instrumented with LLVM source-based coverage, which requires "
+                    "a Clang consumer to link the LLVM profiling runtime." % compiler
+                )

--- a/recipes/wasmi/all/test_package/CMakeLists.txt
+++ b/recipes/wasmi/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.18)
+project(test_package C)
+
+find_package(wasmi REQUIRED CONFIG)
+
+add_executable(test_package test_package.c)
+target_link_libraries(test_package PRIVATE wasmi::wasmi)

--- a/recipes/wasmi/all/test_package/conanfile.py
+++ b/recipes/wasmi/all/test_package/conanfile.py
@@ -1,0 +1,30 @@
+from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps, cmake_layout
+from conan.tools.build import can_run
+import os
+
+
+class WasmiTestConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def generate(self):
+        deps = CMakeDeps(self)
+        deps.generate()
+        tc = CMakeToolchain(self)
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/wasmi/all/test_package/test_package.c
+++ b/recipes/wasmi/all/test_package/test_package.c
@@ -1,0 +1,10 @@
+#include <wasmi.h>
+
+int main(void) {
+    wasm_engine_t *engine = wasm_engine_new();
+    if (engine == NULL) {
+        return 1;
+    }
+    wasm_engine_delete(engine);
+    return 0;
+}


### PR DESCRIPTION
and the addition of a test package for that recipe.