### PR TITLE
opentelemetry-cpp: add versions 1.27.0 and 1.28.0

### DIFF
--- a/recipes/opentelemetry-cpp/all/conandata.yml
+++ b/recipes/opentelemetry-cpp/all/conandata.yml
@@ -1,4 +1,10 @@
 sources:
+  "1.28.0":
+    url: "https://github.com/open-telemetry/opentelemetry-cpp/archive/v1.28.0.tar.gz"
+    sha256: "8c359919175d77c502515f5a783907d031cc6a172e44426dbe9bee3c1532201e"
+  "1.27.0":
+    url: "https://github.com/open-telemetry/opentelemetry-cpp/archive/v1.27.0.tar.gz"
+    sha256: "d09c2e8dd95bbc1d6ee493a89f32a4736879948d0eb59ad58c855022d1f55cc1"
   "1.26.0":
     url: "https://github.com/open-telemetry/opentelemetry-cpp/archive/v1.26.0.tar.gz"
     sha256: "8a878777a18a013e0ee6604629d1b5f29b162354c14489ad1dccd370f14ac372"

--- a/recipes/opentelemetry-cpp/config.yml
+++ b/recipes/opentelemetry-cpp/config.yml
@@ -1,4 +1,8 @@
 versions:
+  "1.28.0":
+    folder: all
+  "1.27.0":
+    folder: all
   "1.26.0":
     folder: all
   "1.24.0":


### PR DESCRIPTION
Specify library name and version: **opentelemetry-cpp/1.27.0**, **opentelemetry-cpp/1.28.0**

Upgrade driver: **1.26.0 and earlier are affected by [CVE-2026-44967](https://github.com/open-telemetry/opentelemetry-cpp/security/advisories/GHSA-5qhm-4rfp-qqvj)** (GHSA-5qhm-4rfp-qqvj, medium, CVSS 5.3). The OTLP HTTP exporters read the full HTTP response into memory with no size cap, allowing memory exhaustion via a malicious or misconfigured collector endpoint. Fixed in **1.27.0** ([#4078](https://github.com/open-telemetry/opentelemetry-cpp/pull/4078)), which caps responses at 4 MiB.

This matters for the currently published recipe because `with_otlp_http` defaults to `True`, so the affected code path is enabled by default. API-only consumers are unaffected.

1.28.0 is included so the fork tracks the current upstream release rather than the minimum patched one.

| Version | sha256 |
| --- | --- |
| 1.27.0 | `d09c2e8dd95bbc1d6ee493a89f32a4736879948d0eb59ad58c855022d1f55cc1` |
| 1.28.0 | `8c359919175d77c502515f5a783907d031cc6a172e44426dbe9bee3c1532201e` |

No `conanfile.py` changes needed — the existing version gates (`< 1.22.0` proto patch, `>= 1.24.0` cmake tool requirement) already cover both, the `_patch_sources` anchors still match, and 1.28.0's one new target (`opentelemetry_http_client`) is an `INTERFACE` library with no artifact to link.

`conan create` + `test_package` pass for both versions on two configs: gcc 15 / Conan 2.23 / Debug / cppstd=17, and gcc 15.2 / Conan 2.30 / Release / gnu17.
