### PR TITLE
opentelemetry-cpp: export versions 1.27.0 and 1.28.0

### DIFF
--- a/export_all.sh
+++ b/export_all.sh
@@ -26,6 +26,8 @@ export_recipe grpc/all 1.81.1
 export_recipe mpt-crypto/all 1.0.2
 export_recipe openssl/3.x.x 3.5.7
 export_recipe openssl/3.x.x 3.6.3
+export_recipe opentelemetry-cpp/all 1.27.0
+export_recipe opentelemetry-cpp/all 1.28.0
 export_recipe secp256k1/all 0.7.1
 export_recipe snappy/all 1.1.10
 export_recipe wasm-xrplf/all 2.4.1-xrplf


### PR DESCRIPTION
## Summary

Adds `opentelemetry-cpp` 1.27.0 and 1.28.0 to `export_all.sh` so they actually reach the Conan remote.

## Motivation

#80 added both versions to `recipes/opentelemetry-cpp/config.yml` and `all/conandata.yml`, but those files alone don't publish anything. `export-one-remote.yml` runs `./export_all.sh` — which exports an explicit hardcoded list of recipes into the Conan cache — and then uploads `'*'`, i.e. only what that script exported. `opentelemetry-cpp` was never on the list, so nothing was uploaded and CI still went green.

The result is that the remote has no `opentelemetry-cpp` recipe at all:

```
$ conan search opentelemetry-cpp -r xrplf
ERROR: Recipe 'opentelemetry-cpp' not found
```

Upstream conan-io/conan-center-index also tops out at 1.26.0, so there is currently no remote anywhere serving 1.27.0 or 1.28.0.

This breaks `conan/lockfile/regenerate.sh` in rippled once `conanfile.py` requires 1.28.0. That script deliberately resolves inside a throwaway `CONAN_HOME` to keep lockfiles reproducible, so it cannot fall back on a locally exported recipe:

```
ERROR: Package 'opentelemetry-cpp/1.28.0' not resolved:
       Unable to find 'opentelemetry-cpp/1.28.0' in remotes.
```

## Verification

- Both versions pass the `yq --exit-status '.sources | has(...)'` guard in `export_recipe` (present in `conandata.yml` `sources:` and in `config.yml` `versions:` → `folder: all`).
- Both export cleanly into a clean `CONAN_HOME`:
  ```
  opentelemetry-cpp/1.27.0: Exported: opentelemetry-cpp/1.27.0#2cbf71db4e0e0535df20be305005cb2f
  opentelemetry-cpp/1.28.0: Exported: opentelemetry-cpp/1.28.0#2cbf71db4e0e0535df20be305005cb2f
  ```
- With both exported, rippled's lockfile step resolves as expected:
  ```
  opentelemetry-cpp/1.28.0#2cbf71db4e0e0535df20be305005cb2f
  ```

## Note on merge behaviour

`export-one-remote.yml` gates the real upload on `github.repository_owner == 'XRPLF' && github.event_name != 'pull_request'`, so the PR run is dry-run only — the recipes are published when this merges to `master`.

1.27.0 is included alongside 1.28.0 for consistency with #80, which added both.
