### PR TITLE
Update mpt-crypto to 1.0.4

### DIFF
--- a/export_all.sh
+++ b/export_all.sh
@@ -24,7 +24,7 @@ export_recipe abseil/all 20250127.0
 export_recipe corrosion/all 0.6.1
 export_recipe ed25519/all 2015.03
 export_recipe grpc/all 1.81.1
-export_recipe mpt-crypto/all 1.0.2
+export_recipe mpt-crypto/all 1.0.4
 export_recipe openssl/3.x.x 3.5.7
 export_recipe openssl/3.x.x 3.6.3
 export_recipe opentelemetry-cpp/all 1.27.0

--- a/recipes/mpt-crypto/all/conandata.yml
+++ b/recipes/mpt-crypto/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.0.4":
+    url: https://github.com/XRPLF/mpt-crypto/archive/refs/tags/1.0.4.zip
+    sha256: 97e8636e3e1b8a1fc272b1d9221dd03e983aa4282368c527abb470a61b1327c7
   "1.0.2":
     url: https://github.com/XRPLF/mpt-crypto/archive/refs/tags/1.0.2.zip
     sha256: 171f27d8acf88a030bb2480f0aedbfdc523445e429729b824fdd7384cdd730b1

--- a/recipes/mpt-crypto/config.yml
+++ b/recipes/mpt-crypto/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.0.4":
+    folder: all
   "1.0.2":
     folder: all
   "1.0.1":


### PR DESCRIPTION
   ## Description

   Update `mpt-crypto` to version `1.0.4` in the Conan Center recipe.

   ## Changes

   - `recipes/mpt-crypto/all/conandata.yml`
     - Add new source entry for `1.0.4`:
       - `url: https://github.com/XRPLF/mpt-crypto/archive/refs/tags/1.0.4.zip`
       - `sha256: 97e8636e3e1b8a1fc272b1d9221dd03e983aa4282368c527abb470a61b1327c7`
   - `recipes/mpt-crypto/config.yml`
     - Add version `1.0.4` mapping to `folder: all`
   - `export_all.sh`
     - Update `mpt-crypto/all` export version from `1.0.2` to `1.0.4`

   ## Notes

   - I checked this repo history and found no existing PR for `mpt-crypto 1.0.4`.