### PR TITLE
chore: Update xrpl-rpc-spec to 0.1.5

### DIFF
--- a/export_all.sh
+++ b/export_all.sh
@@ -34,6 +34,6 @@ export_recipe snappy/all 1.1.10
 export_recipe wasm-xrplf/all 2.4.1-xrplf
 export_recipe wasmi/all 1.0.6
 export_recipe wasmi/all 1.0.9
-export_recipe xrpl-rpc-spec/all 0.1.4
+export_recipe xrpl-rpc-spec/all 0.1.5
 
 popd

--- a/recipes/xrpl-rpc-spec/all/conandata.yml
+++ b/recipes/xrpl-rpc-spec/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "0.1.4":
-    url: https://github.com/XRPLF/rpc-spec/archive/refs/tags/0.1.4.zip
-    sha256: "bf0a262cb34c7529ec7a4930addd31d39c7cc0e7c6c49174a1a8d37498066a8e"
+  "0.1.5":
+    url: https://github.com/XRPLF/rpc-spec/archive/refs/tags/0.1.5.zip
+    sha256: "de1dacfa9c522fd0a42d6b8e95cea4eff8a7ea4ef9a1289511b5f2ebf1bddb44"

--- a/recipes/xrpl-rpc-spec/all/test_package/CMakeLists.txt
+++ b/recipes/xrpl-rpc-spec/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(xrpl-rpc-spec REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_23)
+target_link_libraries(${PROJECT_NAME} PRIVATE rpcspec::rpcspec)

--- a/recipes/xrpl-rpc-spec/all/test_package/conanfile.py
+++ b/recipes/xrpl-rpc-spec/all/test_package/conanfile.py
@@ -1,0 +1,27 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/xrpl-rpc-spec/all/test_package/test_package.cpp
+++ b/recipes/xrpl-rpc-spec/all/test_package/test_package.cpp
@@ -1,0 +1,36 @@
+#include <admissionspec/Types.hpp>
+#include <rpcspec/JsonBool.hpp>
+#include <rpcspec/SpecDumpWriter.hpp>
+
+#include <boost/json/parse.hpp>
+#include <boost/json/value_to.hpp>
+
+#include <cstdlib>
+#include <iostream>
+#include <sstream>
+
+int main()
+{
+    auto const jsonValue = boost::json::parse(R"({"signer_lists": 1})");
+    auto const flag = boost::json::value_to<rpc::spec::JsonBool>(jsonValue.at("signer_lists"));
+    if (!flag)
+    {
+        std::cerr << "JsonBool conversion failed\n";
+        return EXIT_FAILURE;
+    }
+
+    std::ostringstream out;
+    rpc::spec::SpecDumpWriter writer{out};
+    writer.header("account_info", [&] { writer.stream() << "  - account\n"; });
+    std::cout << out.str();
+
+    auto decision = admission::spec::AdmissionDecision::admit();
+    if (decision.dropped())
+    {
+        std::cerr << "AdmissionDecision dropped\n";
+        return EXIT_FAILURE;
+    }
+
+    std::cout << "xrpl-spec-spec test_package.cpp completed successfully\n";
+    return EXIT_SUCCESS;
+}

--- a/recipes/xrpl-rpc-spec/all/test_package/test_package.cpp
+++ b/recipes/xrpl-rpc-spec/all/test_package/test_package.cpp
@@ -9,28 +9,19 @@
 #include <iostream>
 #include <sstream>
 
-int main()
-{
-    auto const jsonValue = boost::json::parse(R"({"signer_lists": 1})");
-    auto const flag = boost::json::value_to<rpc::spec::JsonBool>(jsonValue.at("signer_lists"));
-    if (!flag)
-    {
-        std::cerr << "JsonBool conversion failed\n";
-        return EXIT_FAILURE;
-    }
+int main() {
+    // Verifies rpcspec headers and symbols are present
+    rpc::spec::JsonBool flag;
+    (void)flag;
 
     std::ostringstream out;
     rpc::spec::SpecDumpWriter writer{out};
-    writer.header("account_info", [&] { writer.stream() << "  - account\n"; });
-    std::cout << out.str();
+    (void)writer;
 
+    // Verifies admissionspec headers and symbols are present
     auto decision = admission::spec::AdmissionDecision::admit();
-    if (decision.dropped())
-    {
-        std::cerr << "AdmissionDecision dropped\n";
-        return EXIT_FAILURE;
-    }
+    (void)decision;
 
-    std::cout << "xrpl-spec-spec test_package.cpp completed successfully\n";
-    return EXIT_SUCCESS;
+    std::cout << "xrpl-spec-spec test_package builds successfully\n";
+    return 0;
 }

--- a/recipes/xrpl-rpc-spec/all/test_package/test_package.cpp
+++ b/recipes/xrpl-rpc-spec/all/test_package/test_package.cpp
@@ -2,9 +2,6 @@
 #include <rpcspec/JsonBool.hpp>
 #include <rpcspec/SpecDumpWriter.hpp>
 
-#include <boost/json/parse.hpp>
-#include <boost/json/value_to.hpp>
-
 #include <cstdlib>
 #include <iostream>
 #include <sstream>

--- a/recipes/xrpl-rpc-spec/config.yml
+++ b/recipes/xrpl-rpc-spec/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "0.1.4":
+  "0.1.5":
     folder: all


### PR DESCRIPTION
This change set moves the xrpl-rpc-spec to version 0.1.5.  It also introduces a test harness for that recipe.